### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   extension-ci:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
-      go_version: '^1.25.9'
+      go_version: '^1.26.2'
       build_linux_packages: true
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Bump Go to 1.26.2
+
 ## v2.1.16
 
 - Bump Go to 1.25.9

--- a/extinstance/instance_discovery.go
+++ b/extinstance/instance_discovery.go
@@ -9,7 +9,6 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_commons"
 	"github.com/steadybit/discovery-kit/go/discovery_kit_sdk"
 	"github.com/steadybit/extension-kit/extbuild"
-	"github.com/steadybit/extension-kit/extutil"
 	"github.com/steadybit/extension-prometheus/v2/config"
 	"time"
 )
@@ -34,7 +33,7 @@ func (d *instanceDiscovery) Describe() discovery_kit_api.DiscoveryDescription {
 	return discovery_kit_api.DiscoveryDescription{
 		Id: PrometheusInstanceTargetId,
 		Discover: discovery_kit_api.DescribingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr("30s"),
+			CallInterval: new("30s"),
 		},
 	}
 }
@@ -43,9 +42,9 @@ func (d *instanceDiscovery) DescribeTarget() discovery_kit_api.TargetDescription
 	return discovery_kit_api.TargetDescription{
 		Id:       PrometheusInstanceTargetId,
 		Label:    discovery_kit_api.PluralLabel{One: "Prometheus Instance", Other: "Prometheus Instances"},
-		Category: extutil.Ptr("monitoring"),
+		Category: new("monitoring"),
 		Version:  extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:     extutil.Ptr(PrometheusIcon),
+		Icon:     new(PrometheusIcon),
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{
 				{Attribute: "prometheus.instance.name"},

--- a/extmetric/extmetric.go
+++ b/extmetric/extmetric.go
@@ -54,15 +54,15 @@ func (f MetricCheckAction) Describe() action_kit_api.ActionDescription {
 		Description: "Gather and check on Prometheus metrics",
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:        extutil.Ptr(extinstance.PrometheusIcon),
-		Technology:  extutil.Ptr("Prometheus"),
+		Technology:  new("Prometheus"),
 
-		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
+		TargetSelection: new(action_kit_api.TargetSelection{
 			TargetType:          extinstance.PrometheusInstanceTargetId,
 			QuantityRestriction: extutil.Ptr(action_kit_api.QuantityRestrictionExactlyOne),
-			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
+			SelectionTemplates: new([]action_kit_api.TargetSelectionTemplate{
 				{
 					Label:       "instance-name",
-					Description: extutil.Ptr("Find prometheus-instance by instance-name"),
+					Description: new("Find prometheus-instance by instance-name"),
 					Query:       "prometheus.instance.name=\"\"",
 				},
 			}),
@@ -74,23 +74,23 @@ func (f MetricCheckAction) Describe() action_kit_api.ActionDescription {
 				Label:        "Duration",
 				Name:         "duration",
 				Type:         action_kit_api.ActionParameterTypeDuration,
-				Advanced:     extutil.Ptr(false),
-				Required:     extutil.Ptr(true),
-				DefaultValue: extutil.Ptr("30s"),
+				Advanced:     new(false),
+				Required:     new(true),
+				DefaultValue: new("30s"),
 			},
 		},
 		Prepare: action_kit_api.MutatingEndpointReference{},
 		Start:   action_kit_api.MutatingEndpointReference{},
-		Metrics: extutil.Ptr(action_kit_api.MetricsConfiguration{
-			Query: extutil.Ptr(action_kit_api.MetricsQueryConfiguration{
+		Metrics: new(action_kit_api.MetricsConfiguration{
+			Query: new(action_kit_api.MetricsQueryConfiguration{
 				Endpoint: action_kit_api.MutatingEndpointReferenceWithCallInterval{
-					CallInterval: extutil.Ptr("1s"),
+					CallInterval: new("1s"),
 				},
 				Parameters: []action_kit_api.ActionParameter{
 					{
 						Name:     "query",
 						Label:    "PromQL Query",
-						Required: extutil.Ptr(true),
+						Required: new(true),
 						Type:     action_kit_api.ActionParameterTypeString,
 					},
 				},
@@ -110,17 +110,17 @@ func (f MetricCheckAction) Start(_ context.Context, _ *MetricCheckState) (*actio
 func (f MetricCheckAction) QueryMetrics(ctx context.Context, request action_kit_api.QueryMetricsRequestBody) (*action_kit_api.QueryMetricsResult, error) {
 	instance, err := extinstance.FindInstanceByName(request.Target.Name)
 	if err != nil {
-		return nil, extutil.Ptr(extension_kit.ToError(fmt.Sprintf("Failed to find Prometheus instance named '%s'", request.Target.Name), err))
+		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to find Prometheus instance named '%s'", request.Target.Name), err))
 	}
 
 	client, err := instance.GetApiClient()
 	if err != nil {
-		return nil, extutil.Ptr(extension_kit.ToError("Failed to initialize Prometheus API client", err))
+		return nil, new(extension_kit.ToError("Failed to initialize Prometheus API client", err))
 	}
 
 	query := request.Config["query"]
 	if query == nil {
-		return nil, extutil.Ptr(extension_kit.ToError("No PromQL query defined", nil))
+		return nil, new(extension_kit.ToError("No PromQL query defined", nil))
 	}
 
 	retries := config.Config.QueryRetries
@@ -150,7 +150,7 @@ func (f MetricCheckAction) QueryMetrics(ctx context.Context, request action_kit_
 		return nil
 	})
 	if err != nil {
-		return nil, extutil.Ptr(extension_kit.ToError(fmt.Sprintf("Failed to execute Prometheus range query against instance '%s' from %s to %s with query '%s'",
+		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to execute Prometheus range query against instance '%s' from %s to %s with query '%s'",
 			request.Target.Name,
 			start,
 			end,
@@ -161,7 +161,7 @@ func (f MetricCheckAction) QueryMetrics(ctx context.Context, request action_kit_
 	// QueryRange returns a matrix instead of a vector
 	matrix, ok := result.(model.Matrix)
 	if !ok {
-		return nil, extutil.Ptr(extension_kit.ToError("PromQL range query returned unexpected result. Expected matrix type as query result", nil))
+		return nil, new(extension_kit.ToError("PromQL range query returned unexpected result. Expected matrix type as query result", nil))
 	}
 
 	// Process the matrix result
@@ -189,8 +189,8 @@ func (f MetricCheckAction) QueryMetrics(ctx context.Context, request action_kit_
 		}
 	}
 
-	return extutil.Ptr(action_kit_api.QueryMetricsResult{
-		Metrics: extutil.Ptr(metrics),
+	return new(action_kit_api.QueryMetricsResult{
+		Metrics: new(metrics),
 	}), nil
 }
 

--- a/extmetric/extmetric_test.go
+++ b/extmetric/extmetric_test.go
@@ -15,7 +15,6 @@ import (
 	dcontainer "github.com/docker/docker/api/types/container"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_sdk"
-	"github.com/steadybit/extension-kit/extutil"
 	"github.com/steadybit/extension-prometheus/v2/config"
 	"github.com/steadybit/extension-prometheus/v2/extinstance"
 	"github.com/stretchr/testify/assert"
@@ -97,11 +96,11 @@ func getTestMetric(instance extinstance.Instance) (*action_kit_api.QueryMetricsR
 	action := NewMetricCheckAction().(action_kit_sdk.ActionWithMetricQuery[MetricCheckState])
 
 	return action.QueryMetrics(context.Background(), action_kit_api.QueryMetricsRequestBody{
-		Target: extutil.Ptr(action_kit_api.Target{
+		Target: new(action_kit_api.Target{
 			Name: instance.Name,
 		}),
 		Timestamp: timestamp,
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"query": "up",
 		},
 	})

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/steadybit/extension-prometheus/v2
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
## Summary
- Bump Go to 1.26.2 in go.mod, ci.yml, and Dockerfile
- Apply `go fix ./...` changes