### PR TITLE
docs: align CONTRIBUTING with canonical template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,44 @@
 # Contributing
 
-## Running Locally
+## Prerequisites
+
+To build and run this extension locally, you need:
+
+- [Go](https://go.dev/dl/) 1.26 or later
+- [GNU Make](https://www.gnu.org/software/make/)
+- [GoReleaser](https://goreleaser.com/) (used by `make build`)
+- [Docker](https://www.docker.com/) (required for `make container` and container-based tests)
+- [Helm](https://helm.sh/docs/intro/install/) and [helm-unittest](https://github.com/helm-unittest/helm-unittest) (for chart development; `make charttesting` and `make chartlint`)
+
+## Getting Started
+
+1. Clone the repository
+2. `$ make tidy`
+3. `$ make run`
+4. `$ open http://localhost:8080`
+
+## Tasks
+
+The `Makefile` in the project root contains commands to easily run common admin tasks. Run `make help` to list all available targets.
+
+| Command            | Meaning                                                                                               |
+|--------------------|-------------------------------------------------------------------------------------------------------|
+| `$ make tidy`      | Format all code using `go fmt` and tidy the `go.mod` file.                                            |
+| `$ make audit`     | Run `go vet`, `staticcheck`, execute all tests and verify required modules.                           |
+| `$ make build`     | Build a binary for the extension. Creates a file called `extension` in the repository root directory. |
+| `$ make run`       | Build and then run the created binary.                                                                |
+| `$ make container` | Build the container image (`extension-prometheus:latest`) using Docker buildx.                        |
+
+## Running Against a Local Prometheus
 
 ### Installing Prometheus Through Homebrew
-
-#### Installation
 
 ```sh
 brew install prometheus
 brew services start prometheus
 ```
 
-#### Configuration
-
-Through `/opt/homebrew/etc`.
-
-##### Scrape Configs for Local Platform & Agent
-
-Add the following to the `prometheus.yml`.
+Configuration lives under `/opt/homebrew/etc`. Add the following scrape configs to `prometheus.yml` to point at a locally running Steadybit platform and agent:
 
 ```yaml
 scrape_configs:
@@ -47,6 +68,27 @@ go run .
 ## References
 
  - [Collection of sample queries & alert rules](https://awesome-prometheus-alerts.grep.to/)
+
+## Releasing the Code/Docker Image
+
+To make a new release, do the following:
+
+ 1. Update the `CHANGELOG.md`
+ 2. Commit and push the changelog changes.
+ 3. Set the tag `git tag -a vX.X.X -m vX.X.X`
+ 4. Push the tag.
+
+## Releasing Helm Chart Changes
+
+ 1. Update the version number in the [Chart.yaml](./charts/steadybit-extension-prometheus/Chart.yaml)
+ 2. Commit and push the changes.
+
+Changing the Helm chart without bumping the version will result in the following error:
+
+```
+> Releasing charts...
+    Error: error creating GitHub release steadybit-extension-prometheus-1.0.0: POST https://api.github.com/repos/steadybit/extension-prometheus/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
+```
 
 ## Contributor License Agreement (CLA)
 


### PR DESCRIPTION
## Summary

Standardize the CONTRIBUTING.md structure across Steadybit extension repositories while preserving the Prometheus-specific local setup notes.

- Add an explicit **Prerequisites** section listing the build tools and minimum versions (Go 1.26, Make, GoReleaser, Docker, Helm + helm-unittest).
- Reference the actual Makefile targets, including `make container`, and link to `make help` for discoverability.
- Preserve the existing Homebrew Prometheus setup and References sections under a renamed **Running Against a Local Prometheus** heading.
- Keep release flow (binary + Helm chart) unchanged so downstream automation is not affected.