### PR TITLE
fix: guard non-string PromQL query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: return a clear error instead of panicking when the PromQL `query` parameter is not a string
+
 ## v2.1.21
 
 - build(deps): bump alpine from 3.23 to 3.24

--- a/extmetric/extmetric.go
+++ b/extmetric/extmetric.go
@@ -118,9 +118,13 @@ func (f MetricCheckAction) QueryMetrics(ctx context.Context, request action_kit_
 		return nil, new(extension_kit.ToError("Failed to initialize Prometheus API client", err))
 	}
 
-	query := request.Config["query"]
-	if query == nil {
+	queryValue := request.Config["query"]
+	if queryValue == nil {
 		return nil, new(extension_kit.ToError("No PromQL query defined", nil))
+	}
+	query, ok := queryValue.(string)
+	if !ok {
+		return nil, new(extension_kit.ToError("PromQL query must be a string", nil))
 	}
 
 	retries := config.Config.QueryRetries
@@ -138,12 +142,12 @@ func (f MetricCheckAction) QueryMetrics(ctx context.Context, request action_kit_
 
 	var result model.Value
 	err = retry.Do(ctx, retry.WithMaxRetries(uint64(retries), retry.NewFibonacci(50*time.Millisecond)), func(ctx context.Context) error {
-		value, warnings, err := client.QueryRange(ctx, query.(string), r)
+		value, warnings, err := client.QueryRange(ctx, query, r)
 		if err != nil {
 			return retry.RetryableError(err)
 		}
 		if len(warnings) > 0 {
-			log.Info().Str("query", query.(string)).Strs("warnings", warnings).Msg("Warnings returned from query.")
+			log.Info().Str("query", query).Strs("warnings", warnings).Msg("Warnings returned from query.")
 		}
 
 		result = value


### PR DESCRIPTION
## Problem (MAJOR)

`QueryMetrics` only nil-checked `request.Config["query"]`, then asserted `query.(string)` inside the retry closure (and in the warnings log). If the value were not a string (a malformed request sending a number/bool/object), the assertion panics rather than failing the metric check gracefully.

## Fix

Assert the type once, right after the nil check, returning a clear error if it isn't a string; the rest of the function uses the typed `string`.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean; `go test ./extmetric/` passes.

## /simplify
Skipped the multi-agent pass — trivial type-assertion guard (self-reviewed clean).